### PR TITLE
Fix links to Inspire.js

### DIFF
--- a/chroma-zone/index.html
+++ b/chroma-zone/index.html
@@ -5,8 +5,8 @@
 <meta charset="utf-8" />
 <title>The Chroma Zone: Engineering color on the Web</title>
 
-<link href="../../inspire.js/inspire.css" rel="stylesheet" />
-<link href="../../inspire.js/theme.css" rel="stylesheet" />
+<link href="https://inspirejs.org/inspire.css" rel="stylesheet" />
+<link href="https://inspirejs.org/theme.css" rel="stylesheet" />
 <link href="../shared/prism.css" rel="stylesheet" />
 <link href="theme.css" rel="stylesheet" />
 <link href="rgb-cube.css" rel="stylesheet" />
@@ -763,7 +763,7 @@ background: shade(red, 10%); /* &rarr; #e50000 */</code></pre>
 <script src="../shared/js/bliss.shy.min.js"></script>
 <script src="../shared/js/prism.js"></script>
 <script src="../incrementable/incrementable.js"></script>
-<script src="../../inspire.js/inspire.js"></script>
+<script src="https://inspirejs.org/inspire.mjs" type="module"></script>
 <script src="color.js"></script>
 <script src="talk.js"></script>
 

--- a/color-api/index.html
+++ b/color-api/index.html
@@ -4,8 +4,8 @@
 
 <meta charset="utf-8" />
 <title>Towards a color space agnostic Color object for the Web Platform</title>
-<link href="../../inspire.js/inspire.css" rel="stylesheet" />
-<link href="../../inspire.js/theme.css" rel="stylesheet" />
+<link href="https://inspirejs.org/inspire.css" rel="stylesheet" />
+<link href="https://inspirejs.org/theme.css" rel="stylesheet" />
 <link href="../shared/prism.css" rel="stylesheet" />
 <link href="../web-design-cheat-code/theme.css" rel="stylesheet" />
 <link rel="stylesheet" href="../../color.js/notebook/color-notebook.css">
@@ -466,7 +466,7 @@
 <script src="../shared/js/bliss.shy.min.js"></script>
 <script src="../shared/js/prism.js"></script>
 <script src="../incrementable/incrementable.js"></script>
-<script src="../../inspire.js/inspire.js"></script>
+<script src="https://inspirejs.org/inspire.mjs" type="module"></script>
 <script src="talk.js" type="module"></script>
 
 </body>

--- a/css-variables/index.html
+++ b/css-variables/index.html
@@ -4,8 +4,8 @@
 
 <meta charset="utf-8" />
 <title>CSS Variables: var(--subtitle);</title>
-<link href="../../inspire.js/inspire.css" rel="stylesheet" />
-<link href="../../inspire.js/theme.css" rel="stylesheet" />
+<link href="https://inspirejs.org/inspire.css" rel="stylesheet" />
+<link href="https://inspirejs.org/theme.css" rel="stylesheet" />
 <link href="../shared/intro-outro.css" rel="stylesheet" />
 <link href="prism.css" rel="stylesheet" />
 <link href="theme.css" rel="stylesheet" />
@@ -941,7 +941,7 @@
 <script src="../shared/js/bliss.shy.min.js"></script>
 <script src="../shared/js/prism.js"></script>
 <script src="../incrementable/incrementable.js"></script>
-<script src="../../inspire.js/inspire.js"></script>
+<script src="https://inspirejs.org/inspire.mjs" type="module"></script>
 <script src="talk.js"></script>
 
 </body>

--- a/even-more-css-secrets/index.html
+++ b/even-more-css-secrets/index.html
@@ -4,8 +4,8 @@
 
 <meta charset="utf-8" />
 <title>Even More CSS Secrets</title>
-<link href="../../inspire.js/inspire.css" rel="stylesheet" />
-<link href="../../inspire.js/theme.css" rel="stylesheet" />
+<link href="https://inspirejs.org/inspire.css" rel="stylesheet" />
+<link href="https://inspirejs.org/theme.css" rel="stylesheet" />
 <link href="../shared/intro-outro.css" rel="stylesheet" />
 <link href="../shared/prism.css" rel="stylesheet" />
 <link href="theme.css" rel="stylesheet" />
@@ -984,7 +984,7 @@
 <script src="../shared/js/bliss.shy.min.js"></script>
 <script src="../shared/js/prism.js"></script>
 <script src="../incrementable/incrementable.js"></script>
-<script src="../../inspire.js/inspire.js"></script>
+<script src="https://inspirejs.org/inspire.mjs" type="module"></script>
 <script src="talk.js"></script>
 
 <script src="//dev.mavo.io/dist/mavo.js"></script>

--- a/html-reimagined/index.html
+++ b/html-reimagined/index.html
@@ -4,8 +4,8 @@
 
 <meta charset="utf-8" />
 <title>Mavo: Creating Interactive Data-Driven Web Applications by Authoring HTML</title>
-<link href="../../inspire.js/inspire.css" rel="stylesheet" />
-<link href="../../inspire.js/theme.css" rel="stylesheet" />
+<link href="https://inspirejs.org/inspire.css" rel="stylesheet" />
+<link href="https://inspirejs.org/theme.css" rel="stylesheet" />
 <link rel="stylesheet" href="https://dev.mavo.io/dist/mavo.css">
 <link href="../shared/intro-outro.css" rel="stylesheet" />
 <link href="prism.css" rel="stylesheet" />
@@ -815,7 +815,7 @@ Value: [strength]</textarea>
 
 <script src="https://dev.mavo.io/dist/mavo.js"></script>
 <script src="https://blissfuljs.com/bliss.min.js"></script>
-<script src="../../inspire.js/inspire.js"></script>
+<script src="https://inspirejs.org/inspire.mjs" type="module"></script>
 <script src="../shared/js/prism.js"></script>
 <script src="../incrementable/incrementable.js"></script>
 <script src="../shared/js/editor.js"></script>

--- a/jsux/index.html
+++ b/jsux/index.html
@@ -5,7 +5,7 @@
 <meta charset="utf-8" />
 <title>Writing code for humans</title>
 
-<link href="../../inspire.js/inspire.css" rel="stylesheet" />
+<link href="https://inspirejs.org/inspire.css" rel="stylesheet" />
 <link href="../../inspire.js/extras.css" rel="stylesheet" />
 <link href="../shared/intro-outro.css" rel="stylesheet" />
 <link href="../shared/prism.css" rel="stylesheet" />
@@ -1914,7 +1914,7 @@ element.cloneNode(true); // shallow</code></pre>
 
 <script src="../shared/js/prism.js"></script>
 <script src="../incrementable/incrementable.js"></script>
-<script src="../../inspire.js/inspire.js"></script>
+<script src="https://inspirejs.org/inspire.mjs" type="module"></script>
 
 <script src="../../multirange/multirange.js"></script>
 <script src="js/talk.js"></script>

--- a/mavo-actions/index.html
+++ b/mavo-actions/index.html
@@ -4,8 +4,8 @@
 
 <meta charset="utf-8" />
 <title>Extending a Reactive Expression Language with Data Update Actions for End-User Application Authoring</title>
-<link href="../../inspire.js/inspire.css" rel="stylesheet" />
-<link href="../../inspire.js/theme.css" rel="stylesheet" />
+<link href="https://inspirejs.org/inspire.css" rel="stylesheet" />
+<link href="https://inspirejs.org/theme.css" rel="stylesheet" />
 
 <link rel="stylesheet" href="https://dev.mavo.io/dist/mavo.css">
 <link href="../shared/intro-outro.css" rel="stylesheet" />
@@ -888,7 +888,7 @@ set(dice, random(1, 6))</code>
 </footer>
 
 <script src="https://dev.mavo.io/dist/mavo.js"></script>
-<script src="../../inspire.js/inspire.js"></script>
+<script src="https://inspirejs.org/inspire.mjs" type="module"></script>
 <script src="../shared/js/prism.js"></script>
 <script src="https://live.prismjs.com/src/prism-live.js"></script>
 <script src="https://live.prismjs.com/src/prism-live-markup.js"></script>

--- a/reusable/index.html
+++ b/reusable/index.html
@@ -4,8 +4,8 @@
 
 <meta charset="utf-8" />
 <title>Even More CSS Secrets</title>
-<link href="../../inspire.js/inspire.css" rel="stylesheet" />
-<link href="../../inspire.js/theme.css" rel="stylesheet" />
+<link href="https://inspirejs.org/inspire.css" rel="stylesheet" />
+<link href="https://inspirejs.org/theme.css" rel="stylesheet" />
 <link href="../shared/prism.css" rel="stylesheet" />
 <link href="theme.css" rel="stylesheet" />
 <link href="../shared/browser-support.css" rel="stylesheet" />
@@ -120,7 +120,7 @@
 <script src="../shared/js/bliss.shy.min.js"></script>
 <script src="../shared/js/prism.js"></script>
 <script src="../incrementable/incrementable.js"></script>
-<script src="../../inspire.js/inspire.js"></script>
+<script src="https://inspirejs.org/inspire.mjs" type="module"></script>
 <script src="talk.js"></script>
 
 <script src="//dev.mavo.io/dist/mavo.js"></script>

--- a/web-design-cheat-code/index.html
+++ b/web-design-cheat-code/index.html
@@ -4,8 +4,8 @@
 
 <meta charset="utf-8" />
 <title>The Web Design Cheat Code</title>
-<link href="../../inspire.js/inspire.css" rel="stylesheet" />
-<link href="../../inspire.js/theme.css" rel="stylesheet" />
+<link href="https://inspirejs.org/inspire.css" rel="stylesheet" />
+<link href="https://inspirejs.org/theme.css" rel="stylesheet" />
 <link href="../shared/prism.css" rel="stylesheet" />
 <link href="theme.css" rel="stylesheet" />
 <link href="talk.css" rel="stylesheet" />
@@ -634,7 +634,7 @@
 <script src="../shared/js/bliss.shy.min.js"></script>
 <script src="../shared/js/prism.js"></script>
 <script src="../incrementable/incrementable.js"></script>
-<script src="../../inspire.js/inspire.js"></script>
+<script src="https://inspirejs.org/inspire.mjs" type="module"></script>
 <script src="talk.js"></script>
 
 </body>


### PR DESCRIPTION
It fixes the [“Even more CSS secrets”](https://deploy-preview-6--lea-talks.netlify.app/even-more-css-secrets) talk and all other talks suffering from the same issue.