### PR TITLE
Fix Netlify deployment and aggregate workspace redirect rules

### DIFF
--- a/aggregate-redirects.mjs
+++ b/aggregate-redirects.mjs
@@ -1,0 +1,23 @@
+import { readFileSync, writeFileSync, globSync } from "node:fs";
+
+let { workspaces = [] } = JSON.parse(readFileSync("package.json", "utf-8"));
+
+let rules = workspaces
+	.flatMap((p) => globSync(p))
+	.map((dir) => {
+		let rules;
+		try {
+			rules = readFileSync(`${dir}/_redirects`, "utf-8").trim();
+		} catch {
+			return;
+		}
+
+		// /client_modules/foo/* … → /child/client_modules/foo/* …
+		return rules && rules.replace(/(^|\s)\//gm, `$1/${dir}/`);
+	})
+	.filter(Boolean)
+	.join("\n");
+
+if (rules) {
+	writeFileSync("_redirects", rules + "\n");
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
 		"build": "npm run build:css",
 		"watch:css": "npx postcss \"**/*.postcss\" --base . --dir . --ext .css --watch",
 		"watch": "npm run watch:css",
-		"prepare": "npm run prepare --if-present --workspaces"
+		"prepare": "npm run prepare --if-present --workspaces",
+		"postprepare": "node aggregate-redirects.mjs"
 	},
 	"devDependencies": {
 		"nudeps": "^0.2.6",

--- a/whathecolor/nudeps.js
+++ b/whathecolor/nudeps.js
@@ -1,3 +1,3 @@
 export default {
-	mode: "dev",
+	mode: process.env.NETLIFY ? undefined : "dev",
 };


### PR DESCRIPTION
## Summary

- Adds `aggregate-redirects.mjs` — reads each workspace child's `_redirects`, prefixes all paths with the child's directory, and writes a single root `_redirects`
- Adds `postprepare` hook to run the script after all workspace children's `prepare` scripts complete
- Fixes Netlify ignoring child `_redirects` files when the publish directory is the workspace root
- Uses default mode on Netlify so packages are copied instead of symlinked (Netlify can't follow symlinks)

Example transform (`whathecolor/_redirects` → root `_redirects`):
```
/client_modules/foo/*  /client_modules/foo@1.0/:splat  302
↓
/whathecolor/client_modules/foo/*  /whathecolor/client_modules/foo@1.0/:splat  302
```

## Test plan

- [x] `NETLIFY=true npm run prepare` generates correct root `_redirects` with prefixed paths
- [x] Idempotent — re-running produces identical output
- [x] `netlify dev --dir .` serves the whathecolor presentation correctly (slides, notes, navigation)
- [x] All Inspire.js plugins and modules load via the import map
- [x] Deploy preview loads and works: https://deploy-preview-9--lea-talks.netlify.app/whathecolor/

🤖 Generated with [Claude Code](https://claude.com/claude-code)